### PR TITLE
70365 - add grace period for manifests

### DIFF
--- a/charts/radix-acr-cleanup/Chart.yaml
+++ b/charts/radix-acr-cleanup/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1"
+appVersion: "1.2"
 description: A Helm chart for Kubernetes
 name: radix-acr-cleanup
 version: 0.1.0

--- a/cmd/acr-cleanup/main.go
+++ b/cmd/acr-cleanup/main.go
@@ -31,10 +31,11 @@ import (
 )
 
 const (
-	timezone         = "Local"
-	clusterTypeLabel = "clusterType"
-	repositoryLabel  = "repository"
-	isTaggedLabel    = "tagged"
+	timezone            = "Local"
+	clusterTypeLabel    = "clusterType"
+	repositoryLabel     = "repository"
+	isTaggedLabel       = "tagged"
+	manifestGracePeriod = 2 * time.Hour
 )
 
 var nrImagesDeleted = promauto.NewCounterVec(
@@ -200,7 +201,8 @@ func deleteImagesBelongingTo(kubeClient kubernetes.Interface, radixClient radixc
 
 			// If this manifest has a timestamp newer than start,
 			// the list of images might not be correct
-			if manifest.Timestamp.After(start) {
+			// The grace period will prevent images from being deleted if they are created before, but close to, the start time.
+			if isManifestWithinGracePeriod(manifest, start, manifestGracePeriod) {
 				if isNotTaggedForAnyClustertype {
 					addUntaggedImageRetained(clusterType, repository)
 				} else {
@@ -314,6 +316,12 @@ func doesManifestExistInCluster(repository string, manifest manifest.Data, image
 	}
 
 	return manifestExistInCluster
+}
+
+// Test if the manifest was created after a specified time and a grace period
+func isManifestWithinGracePeriod(manifest manifest.Data, time time.Time, gracePeriod time.Duration) bool {
+	createdWithGracePeriod := manifest.Timestamp.Add(gracePeriod)
+	return createdWithGracePeriod.After(time)
 }
 
 // Lists distinct images in cluster based on all RadixDeployments

--- a/cmd/acr-cleanup/main.go
+++ b/cmd/acr-cleanup/main.go
@@ -117,7 +117,8 @@ func maintainImages(kubeClient kubernetes.Interface, radixClient radixclient.Int
 
 	source := rand.NewSource(time.Now().UnixNano())
 	tick := delaytick.New(source, period)
-	for time := range tick {
+	for range tick {
+		time := time.Now()
 		if window.Contains(time) {
 			log.Infof("Start deleting images %s", time)
 			deleteImagesBelongingTo(kubeClient, radixClient, registry, clusterType,

--- a/cmd/acr-cleanup/main_test.go
+++ b/cmd/acr-cleanup/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/equinor/radix-acr-cleanup/pkg/manifest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isManifestWithinGracePeriod(t *testing.T) {
+	created, _ := time.Parse(time.RFC3339, "2010-01-01T15:00:00Z")
+	manifest := manifest.Data{Timestamp: created}
+
+	timeAfter, _ := time.Parse(time.RFC3339, "2010-01-01T16:00:00Z")
+	assert.True(t, isManifestWithinGracePeriod(manifest, timeAfter, 2*time.Hour))
+	assert.False(t, isManifestWithinGracePeriod(manifest, timeAfter, 0))
+
+	timeBefore, _ := time.Parse(time.RFC3339, "2010-01-01T14:00:00Z")
+	assert.True(t, isManifestWithinGracePeriod(manifest, timeBefore, 0))
+}


### PR DESCRIPTION
- add grace period of two hours for newly created images
- use current time when checking if cleanup should run