### PR TITLE
Use ubuntu-latest instead of ubuntu-20.04 (#99)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,4 +47,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58.2
+          version: v1.64.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.22-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.23.6-alpine3.20 AS builder
 
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ HAS_GOLANGCI_LINT := $(shell command -v golangci-lint;)
 
 bootstrap:
 ifndef HAS_GOLANGCI_LINT
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.3
 endif

--- a/charts/radix-acr-cleanup/Chart.yaml
+++ b/charts/radix-acr-cleanup/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.3.0
+appVersion: 1.3.1
 description: A Helm chart for Kubernetes
 name: radix-acr-cleanup
-version: 1.3.0
+version: 1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/equinor/radix-acr-cleanup
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 require (
 	github.com/equinor/radix-common v1.9.7
-	github.com/equinor/radix-operator v1.68.4
+	github.com/equinor/radix-operator v1.72.4
 	github.com/prometheus/client_golang v1.20.2
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtz
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/equinor/radix-common v1.9.7 h1:nLpiDL+YJQocQ5gpAM2BABs5Kib7q5U5MrsRz6/rMhY=
 github.com/equinor/radix-common v1.9.7/go.mod h1:iivhnlJqawn8PuFmwu4Wx6CmNjk6xdB6JIMzsZKUFz8=
-github.com/equinor/radix-operator v1.68.4 h1:mVTI1Op9JnWQ0d38sNkeGZO9bRBbbNVIrPA2pbJOErQ=
-github.com/equinor/radix-operator v1.68.4/go.mod h1:VXrGUhtud67eZpvOesONYWU5nWzRA7u8pIC6gv2mJC8=
+github.com/equinor/radix-operator v1.72.4 h1:eJRxHqkmmbD1HHJEV6k4wpE8shLgZZKEUzjmgtBJpUE=
+github.com/equinor/radix-operator v1.72.4/go.mod h1:oGZF9lLVB8lGtFnnv8wAcFRdqhXbfkgyvWgJW+JAp+0=
 github.com/evanphx/json-patch v5.8.1+incompatible h1:2toJaoe7/rNa1zpeQx0UnVEjqk6z2ecyA20V/zg8vTU=
 github.com/evanphx/json-patch v5.8.1+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=


### PR DESCRIPTION
* Use ubuntu-latest instead of ubuntu-20.04

* Update golangci-lint version to v1.64.3

* bump dependencies

* bump dependencies

* bump dependencies
https://github.com/equinor/radix-private/issues/362