### PR TITLE
chore(ci): bump template-prepare-release-pr to 1.1.0

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   prepare-release-pr:
     name: Prepare release pull request
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@v1.1.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This pull request updates the workflow configuration to use a newer version of a reusable workflow template.

Workflow configuration update:

* Updated the `prepare-release-pr` job in `.github/workflows/prepare-release-pr.yml` to use version `v1.1.0` of the `template-prepare-release-pr.yml` reusable workflow, instead of `v1.0.2`.